### PR TITLE
index.md for earthdata cloud notebooks

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -47,6 +47,7 @@ parts:
         - file: tutorials/IS2_ATL15_surface_height_anomalies/IS2_ATL15_surface_height_anomalies
         - file: external/ICESAT2_ATL10-h5coro_large_scale_time_series
         - file: tutorials/ARCOdata_writingZarrs
+        - file: tutorials/index  
           sections:
           - file: tutorials/NASA-Earthdata-Cloud-Access/1.Intro-Earthdata-Cloud
           - file: tutorials/NASA-Earthdata-Cloud-Access/2.earthdata_search

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -47,7 +47,7 @@ parts:
         - file: tutorials/IS2_ATL15_surface_height_anomalies/IS2_ATL15_surface_height_anomalies
         - file: external/ICESAT2_ATL10-h5coro_large_scale_time_series
         - file: tutorials/ARCOdata_writingZarrs
-        - file: tutorials/index  
+        - file: tutorials/NASA-Earthdata-Cloud-Access/index
           sections:
           - file: tutorials/NASA-Earthdata-Cloud-Access/1.Intro-Earthdata-Cloud
           - file: tutorials/NASA-Earthdata-Cloud-Access/2.earthdata_search

--- a/book/tutorials/NASA-Earthdata-Cloud-Access/index.md
+++ b/book/tutorials/NASA-Earthdata-Cloud-Access/index.md
@@ -1,0 +1,9 @@
+# NASA Earthdata Cloud and data access using earthaccess and icepyx
+
+The following series of tutorials provides background on how to search and access NASA Earthdata. In particular, we provide background on the NASA Earthdata Cloud evolution and general cloud computing considerations, followed by a focus on NASA's ICESat-2 Mission. This introduction is followed by tutorials on two valuable python packages: `earthaccess` and `icepyx`, offering complementary search, access, and subsetting capabilities. 
+
+## The following notebooks are included as part of this series:
+* Introduction to NASA Earthdata Cloud and ICESat-2
+* Using NASA Earthdata Search to Discover Cloud-Hosted Data
+* Introduction to the `earthaccess` python library
+* Using the `icepyx` python library to access ICESat-2 data


### PR DESCRIPTION
This should now pull the earthaccess+icepyx series of tutorials out as its own section under a new index.md. 