### PR TITLE
update syntax so images will render in book

### DIFF
--- a/book/tutorials/NASA-Earthdata-Cloud-Access/1.Intro-Earthdata-Cloud.md
+++ b/book/tutorials/NASA-Earthdata-Cloud-Access/1.Intro-Earthdata-Cloud.md
@@ -20,13 +20,7 @@ This guide was adapted from the following tutorials:
 
 In the past, most of our scientific data analysis workflows have started with searching for data and then downloading that data to a local machine; whether that is the hard drive of your laptop or workstation, or some shared storage device hosted by your institution or research group. This can be a time consuming process if the volume of data is large, even with fast internet. It also requires that you have sufficient disk-space and update your copy every time an updated version of the data is released. If you want to work with data from different geoscience domains, you may have to download data from several data centers. 
 
-![CloudParadigm](./images/shiklomanov-cloud-paradigm.png)
-
-<figure>
-<center>
-    <img src='./images/shiklomanov-cloud-paradigm.png' alt='Earthdata Cloud Transition. Credit: Alexey Shiklomanov, NASA ESDIS'/>
-</center>
-</figure>
+![EarthdataCloudParadigm](./images/shiklomanov-cloud-paradigm.png)
 
 Figure credit: Alexey Shiklomanov, NASA ESDIS Project Scientist, from [The future of NASA Earth Science in the commercial cloud:
 Challenges and opportunities](https://docs.google.com/presentation/d/12mh_8WU9lsrPviBO_MBv2blbjRufXoQmqCB4XGyxQ90/edit?pli=1)
@@ -37,11 +31,7 @@ However, a change is a-foot. New modes of data access are becoming available. Dr
 
 NASA's cloud-hosted storage is known as the Earthdata Cloud; all NASA datasets are being migrated to be available in the cloud. During this transition period, data will still remain freely available for download directly from the DAACs (Distributed Active Archive Centers), which have archived and distributed NASA data for over 20 years.
 
-<figure>
-<center>
-    <img src='./images/NSIDC-DAAC.png' alt='NSIDC DAAC Intro'/>
-</center>
-</figure>
+![NSIDC-DAAC-Intro](./images/NSIDC-DAAC.png)
 
 The NSIDC DAAC now offers all [ICESat-2](https://nsidc.org/data/icesat-2) and [ICESat/GLAS](https://nsidc.org/data/icesat) data products via Earthdata Cloud. A listing of all NSIDC DAAC cloud-hosted data can be found [here](https://nsidc.org/data/earthdata-cloud/data). More details on ICESat-2 below.
 
@@ -98,11 +88,11 @@ Photo: Neuenschwander et. al. 2019, Remote Sens. Env. [DOI](https://doi.org/10.1
 
 The ICESat-2 lidar collects at the single photon level, different from most commercial lidar systems. A lot of additional photons get returned as solar background noise, and removing these unwanted photons is a key part of the algorithms that produce the higher level data products.
 
-<img src="./images/ATL08_signalphotons.jpg" width=450/>
+![signal_photons](./images/ATL08_signalphotons.jpg)
 
 > _Fig. 2. Results from signal finding methods for simulated ATLAS data. Black points show raw point cloud data as ingested from ATL03 product. Blue points overlaid in each plot show which photons each method identified as signal. Top panel reflects the signal photons as identified on the ATL03 data product (medium and high confidence signal photons). Bottom panel reflects the signal photons identified from the ATL08 DRAGANN method._ (Neuenschwander & Pitts, 2019)
 
-Photo: Neuenschwander et. al. 2019, Remote Sens. Env. [DOI](https://doi.org/10.1016/j.rse.2018.11.005)
+Image: Neuenschwander et. al. 2019, Remote Sens. Env. [DOI](https://doi.org/10.1016/j.rse.2018.11.005)
 
 To aggregate all these photons into more manegable chunks, many of the Level-3B products such as [ATL08](https://nsidc.org/data/atl08) consolidate the photons into variable segment lengths.
 

--- a/book/tutorials/NASA-Earthdata-Cloud-Access/2.earthdata_search.md
+++ b/book/tutorials/NASA-Earthdata-Cloud-Access/2.earthdata_search.md
@@ -27,19 +27,11 @@ Step 1. Go to https://search.earthdata.nasa.gov and log in using your Earthdata 
 
 Step 2. Check the **Available in Earthdata Cloud** box in the **Filter Collections** side-bar on the left of the page (Box 1 on the screenshot below).  The Matching Collections will appear in the results box.  All datasets in Earthdata Cloud have a badge showing a cloud symbol and "Earthdata Cloud" next to them.  To narrow the search, we will filter by datasets supported by NSIDC by typing "NSIDC" in the search box (Box 2 on the screen shot below).  If you want, you could narrow the search further using spatial and temporal filters or any of the other filters in the filter collections box.
 
-<figure>
-<center>
-    <img src='./images/Screenshot_EDSC_Searching_Cloud_Datasets.png' alt='Screenshot of Search for Cloud Datasets in Earthdata Search'/>
-</center>
-</figure>
+![Scrnshot-SearchforCloudDatasetsinEarthdataSearch](./images/Screenshot_EDSC_Searching_Cloud_Datasets.png)
 
 Step 3. You can now select the dataset you want by clicking on that dataset.  The Search Results box now contains granules that match your search.  The location of these granules is shown on the map.  The search can be refined using spatial and temporal filters or you can select individual granules using the "+" symbol on each granule search result.  Once you have the data you want, click the **Download All** (Box 1 in the screenshot below). In the sidebar that appears, select **Direct Download** (Box 2 in the screenshot below). Then select **Download Data**.
 
-<figure>
-    <center>
-        <img src='./images/Screenshot_EDSC_getting_s3_links_workflow.png' alt='Screenshot of getting S3 links'/>
-    </center>
-</figure>
+![Scrnshot-getS3links](./images/Screenshot_EDSC_getting_s3_links_workflow.png)
 
 ### Getting S3 links and AWS S3 Credentials
 
@@ -47,11 +39,7 @@ Step 4.  A Download Status window will appear (this may take a short amount of t
 
 Step 5.  To access data in Earthdata Cloud, you need AWS S3 credentials; “accessKeyId”, “secretAccessKey”, and “sessionToken”.  These are temporary credentials that last for one hour.  To get them click on the **Get AWS S3 Credentials** (Box 4 in the screenshot below).   This will open a new page that contains the three credentials.  
 
-<figure>
-    <center>
-        <img src='./images/Screenshot_EDSC_S3_links_credentials.png' alt='Screenshot of S3 links and credentials'/>
-    </center>
-</figure>
+![Scrnshot-S3links+credentials](./images/Screenshot_EDSC_S3_links_credentials.png)
     
 ### Using links and credentials from the command line
 

--- a/book/tutorials/NASA-Earthdata-Cloud-Access/3.earthaccess.ipynb
+++ b/book/tutorials/NASA-Earthdata-Cloud-Access/3.earthaccess.ipynb
@@ -4,9 +4,11 @@
    "cell_type": "markdown",
    "id": "7fd4844a-aee8-4a9c-b22a-02688a8067f9",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "user_expressions": []
    },
    "source": [
+    "# NASA Earthdata Cloud and data access using earthaccess and icepyx\n",
     "# Part 1: Introduction to the `earthaccess` python library\n",
     "\n",
     "## Tutorial Overview\n",
@@ -19,12 +21,8 @@
     "\n",
     "As an example data collection, we use ICESat-2 Land Ice Height (ATL06) granules over the Juneau Icefield, AK, for March and April 2020. ICESat-2 data granules, including ATL06, are stored in HDF5 format. We demonstrate how to open an HDF5 granule and access data variables using `xarray`. Land Ice Heights are then plotted using `hvplot`. \n",
     "\n",
-    "<figure>\n",
-    "<center>\n",
-    "    <img src='./images/atl06_example_plot.png' alt='Example plot using data downloaded in tutorial'/>\n",
-    "    <figcaption> ATL06 Land Ice Heights for the margin of the Juneau Ice Field </figcaption>\n",
-    "</center>\n",
-    "</figure>\n",
+    "![ExamplePlotusingTutorialData](./images/atl06_example_plot.png)\n",
+    "> ATL06 Land Ice Heights for the margin of the Juneau Ice Field\n",
     "\n",
     "### Learning Objectives\n",
     "\n",

--- a/book/tutorials/NASA-Earthdata-Cloud-Access/3.earthaccess.ipynb
+++ b/book/tutorials/NASA-Earthdata-Cloud-Access/3.earthaccess.ipynb
@@ -8,7 +8,6 @@
     "user_expressions": []
    },
    "source": [
-    "# NASA Earthdata Cloud and data access using earthaccess and icepyx\n",
     "# Part 1: Introduction to the `earthaccess` python library\n",
     "\n",
     "## Tutorial Overview\n",


### PR DESCRIPTION
After #89 was merged, the image that had been switched from html to `![]()` syntax started rendering. This PR fixes the other images from the AGU tutorial (@asteiker please let me know if I missed any!). Unfortunately we lose the alt text, but I tried to capture it within the tag.