### PR TITLE
Updated Instructions_for_configuring_AWS_S3_bucket.ipynb

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -44,8 +44,8 @@ parse:
 execute:
   execute_notebooks: 'force'
 #  execute_notebooks: 'cache'
-#  exclude_patterns:
-#    - "**/dataintegration-1.ipynb"
+  exclude_patterns:
+    - "*Instructions_for_configuring_AWS_S3_bucket.ipynb"
 
   allow_errors: false
   # Per-cell notebook execution limit (seconds)


### PR DESCRIPTION
Added descriptive text to the "Writing to the S3 bucket" section in Instructions_for_configuring_AWS_S3_bucket.ipynb; added an exception to _config.yml to prevent execution of this notebook when the Jupyter book is rebuilt.