### PR TITLE
🤖 Update CI jobs to run on `ubuntu-latest`

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -9,7 +9,7 @@ on:
       - 'conda/**'
 jobs:
   add-badge:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout PR
       uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      
+
     - name: Configure NASA Earthdata Login
       env:
         EARTHDATA_USER: ${{ secrets.EARTHDATA_USER}}

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   quality-control:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/repo2docker-PR.yaml
+++ b/.github/workflows/repo2docker-PR.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/repo2docker.yaml
+++ b/.github/workflows/repo2docker.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-image-and-push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/update_fr_template.yaml
+++ b/.github/workflows/update_fr_template.yaml
@@ -9,7 +9,7 @@ env:
 jobs:
   template-update:
     name: Template Update
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository != ${{ env.TEMPLATE_REPO}}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
In this instance, I don't think we have any runner-sensitive steps, so it's probably better to always be on latest.